### PR TITLE
Fix/add schedule

### DIFF
--- a/WebContent/common/floating-cart.css
+++ b/WebContent/common/floating-cart.css
@@ -114,3 +114,28 @@
     border-bottom: 1px solid #ddd;
     padding: 4px 6px;
 }
+
+/* 장바구니 담기 성공 toast — 자동 fade in/out, 2.5초 후 제거 */
+.cart-toast {
+    position: fixed;
+    bottom: 115px;
+    left: 50%;
+    background-color: rgba(40, 40, 40, 0.95);
+    color: #fff;
+    padding: 12px 22px;
+    border-radius: 8px;
+    font-size: 14px;
+    font-weight: 500;
+    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.25);
+    z-index: 2000;
+    pointer-events: none;
+    white-space: nowrap;
+    animation: cartToastInOut 2.5s ease forwards;
+}
+
+@keyframes cartToastInOut {
+    0%   { opacity: 0; transform: translate(-50%, 12px); }
+    10%  { opacity: 1; transform: translate(-50%, 0); }
+    85%  { opacity: 1; transform: translate(-50%, 0); }
+    100% { opacity: 0; transform: translate(-50%, -8px); }
+}

--- a/WebContent/common/floating-cart.js
+++ b/WebContent/common/floating-cart.js
@@ -202,7 +202,23 @@ function saveCartToSession(contextPath, placeId, placeType) {
 			'Content-Type': 'application/x-www-form-urlencoded'
 		},
 		body: data
+	}).then(function (response) {
+		if (response.ok) {
+			showCartToast('장바구니에 담았습니다');
+		}
 	});
+}
+
+function showCartToast(message) {
+	var toast = document.createElement('div');
+	toast.className = 'cart-toast';
+	toast.textContent = message;
+	document.body.appendChild(toast);
+	setTimeout(function () {
+		if (toast.parentNode) {
+			toast.parentNode.removeChild(toast);
+		}
+	}, 2500);
 }
 
 function addCartRow(cartBox, placeId, placeTitle, placeType) {

--- a/WebContent/common/floating-cart.js
+++ b/WebContent/common/floating-cart.js
@@ -81,6 +81,11 @@ function startFloatingCart(contextPath) {
 			return;
 		}
 
+		if ((placeType == 'RESTAURANT' || placeType == 'STAY') && !hasLeisurePlace(cartBox)) {
+			alert('레저스포츠를 먼저 장바구니에 담아주세요.');
+			return;
+		}
+
 		saveCartToSession(contextPath, placeId, placeType);
 		addCartRow(cartBox, placeId, placeTitle, placeType);
 		refreshCartCount(cartBox, countText);

--- a/src/com/letsgo/place/model/dao/PlaceDAO.java
+++ b/src/com/letsgo/place/model/dao/PlaceDAO.java
@@ -489,6 +489,57 @@ public class PlaceDAO implements PlaceDAOInterface {
         return list;
     }
 
+    // 장바구니 내 LEISURE 좌표 기준 반경(km) 내 PLACE 조회 (식당/숙박)
+    public List<PlaceVO> searchNearbyPlaces(String placeType, String centerLon, String centerLat,
+            double radiusKm, String category, String keyword, boolean orderByLike) {
+        List<PlaceVO> list = new ArrayList<>();
+        boolean hasCategory = category != null && !category.isEmpty();
+        boolean hasKeyword = keyword != null && !keyword.isEmpty();
+
+        StringBuilder sql = new StringBuilder()
+                .append("SELECT place_id, title, first_image, addr1, mapx, mapy, like_count FROM (")
+                .append("  SELECT place_id, title, first_image, addr1, mapx, mapy, like_count, ")
+                .append(PlaceQuery.NEARBY_HAVERSINE_KM_TEMPLATE).append(" AS distance_km")
+                .append("  FROM place WHERE place_type = ?")
+                .append("    AND mapx IS NOT NULL AND mapy IS NOT NULL");
+        if (hasCategory) {
+            sql.append("    AND lclssystm3 = ?");
+        }
+        if (hasKeyword) {
+            sql.append("    AND (title LIKE ? OR addr1 LIKE ?)");
+        }
+        sql.append(") WHERE distance_km <= ? ");
+        sql.append(orderByLike ? "ORDER BY like_count DESC, distance_km ASC" : "ORDER BY distance_km ASC");
+
+        try (PreparedStatement stmt = conn.prepareStatement(sql.toString())) {
+            int idx = 1;
+            // Haversine 템플릿 바인딩 순서: (mapy 기준차), (centerLat), (mapx 기준차)
+            stmt.setString(idx++, centerLat);
+            stmt.setString(idx++, centerLat);
+            stmt.setString(idx++, centerLon);
+            stmt.setString(idx++, placeType);
+            if (hasCategory) {
+                stmt.setString(idx++, category);
+            }
+            if (hasKeyword) {
+                String pattern = "%" + keyword + "%";
+                stmt.setString(idx++, pattern);
+                stmt.setString(idx++, pattern);
+            }
+            stmt.setDouble(idx++, radiusKm);
+            try (ResultSet rs = stmt.executeQuery()) {
+                while (rs.next()) {
+                    list.add(new PlaceVO(rs.getString("place_id"), rs.getString("title"), rs.getString("addr1"),
+                            rs.getString("mapx"), rs.getString("mapy"), rs.getString("first_image"),
+                            rs.getInt("like_count"), placeType));
+                }
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return list;
+    }
+
     // 카테고리와 키워드 조건을 모두 만족하는 장소를 좋아요순으로 조회
     public List<PlaceVO> searchPlacesByCategoryAndKeywordOrderByLike(String placeType, String category,
             String keyword) {

--- a/src/com/letsgo/place/model/dao/PlaceDAOInterface.java
+++ b/src/com/letsgo/place/model/dao/PlaceDAOInterface.java
@@ -82,5 +82,10 @@ public interface PlaceDAOInterface {
     // 카테고리 + 키워드 조건 좋아요순 검색
     List<PlaceVO> searchPlacesByCategoryAndKeywordOrderByLike(String placeType, String category, String keyword);
 
-   
+    // 장바구니 내 LEISURE 좌표 기준 반경(km) 내 PLACE 조회 (식당/숙박)
+    //  - category/keyword 는 옵션 (null 또는 빈문자열이면 조건 미적용)
+    //  - orderByLike=true 면 좋아요순, false 면 거리순 (둘 다 반경 필터 내)
+    List<PlaceVO> searchNearbyPlaces(String placeType, String centerLon, String centerLat,
+            double radiusKm, String category, String keyword, boolean orderByLike);
+
 }

--- a/src/com/letsgo/place/model/query/PlaceQuery.java
+++ b/src/com/letsgo/place/model/query/PlaceQuery.java
@@ -55,5 +55,21 @@ public interface PlaceQuery {
 	String SET_COUNTING_SQL = "UPDATE place SET like_count = like_count + 1 WHERE place_id = ?";
 
 	String INSERT_VISIT_ITEM_SQL = "INSERT INTO VISIT_ITEM (VISIT_ITEM_ID, VISIT_ORDER, DISTANCE_TO_NEXT, PLACE_ID, SCHEDULE_ID, SCHEDULE_TYPE) VALUES ((SELECT NVL(MAX(VISIT_ITEM_ID), 0) + 1 FROM VISIT_ITEM), ?, ?, ?, ?, ?)";
+
+	/*
+	 * 장바구니 내 LEISURE 좌표 기준 반경(km) 내 PLACE 조회 (식당/숙박).
+	 *  - Haversine 공식 (지구 반경 6371km, 0.017453292519943295 = π/180)
+	 *  - mapx = 경도, mapy = 위도
+	 *  - 바인딩 순서: placeType, [category], [keywordPattern x2], centerLat(=mapy), centerLat, centerLon(=mapx), radiusKm,
+	 *                그리고 ORDER BY 가 distance 인 경우 centerLat, centerLat, centerLon 추가
+	 *  - 동적 WHERE/ORDER 조합이 복잡해 호출 측에서 직접 SQL 을 조립한다 (PlaceDAO 참고)
+	 */
+	String NEARBY_HAVERSINE_KM_TEMPLATE =
+			"(6371 * 2 * ASIN(SQRT(" +
+			"  POWER(SIN((TO_NUMBER(MAPY) - TO_NUMBER(?)) * 0.017453292519943295 / 2), 2)" +
+			" + COS(TO_NUMBER(MAPY) * 0.017453292519943295)" +
+			"   * COS(TO_NUMBER(?) * 0.017453292519943295)" +
+			"   * POWER(SIN((TO_NUMBER(MAPX) - TO_NUMBER(?)) * 0.017453292519943295 / 2), 2)" +
+			")))";
 }
 

--- a/src/com/letsgo/place/mybatis/dao/PlaceDAOMB.java
+++ b/src/com/letsgo/place/mybatis/dao/PlaceDAOMB.java
@@ -195,4 +195,18 @@ public class PlaceDAOMB implements PlaceDAOInterface {
 		return session.selectOne("PlaceMapper.getPlaceByPlaceId", placeId);
 	}
 
+	@Override
+	public List<PlaceVO> searchNearbyPlaces(String placeType, String centerLon, String centerLat,
+			double radiusKm, String category, String keyword, boolean orderByLike) {
+		Map<String, Object> params = new HashMap<>();
+		params.put("placeType", placeType);
+		params.put("centerLon", centerLon);
+		params.put("centerLat", centerLat);
+		params.put("radiusKm", radiusKm);
+		params.put("category", category);
+		params.put("keywordPattern", (keyword == null || keyword.isEmpty()) ? null : "%" + keyword + "%");
+		params.put("orderByLike", orderByLike);
+		return session.selectList("PlaceMapper.searchNearbyPlaces", params);
+	}
+
 }

--- a/src/com/letsgo/place/mybatis/service/PlaceServiceMB.java
+++ b/src/com/letsgo/place/mybatis/service/PlaceServiceMB.java
@@ -145,6 +145,13 @@ public class PlaceServiceMB implements PlaceServiceInterface {
 		return executeRead(dao -> dao.searchPlacesByCategoryAndKeywordOrderByLike(placeType, category, keyword));
 	}
 
+	@Override
+	public List<PlaceVO> searchNearbyPlaces(String placeType, String centerLon, String centerLat,
+			double radiusKm, String category, String keyword, boolean orderByLike) {
+		return executeRead(dao -> dao.searchNearbyPlaces(
+				placeType, centerLon, centerLat, radiusKm, category, keyword, orderByLike));
+	}
+
 	//조회 공통 처리
 	private <T> T executeRead(Function<PlaceDAOInterface, T> action) {
 		return withSession(session -> {

--- a/src/com/letsgo/place/service/PlaceService.java
+++ b/src/com/letsgo/place/service/PlaceService.java
@@ -195,8 +195,11 @@ public class PlaceService implements PlaceServiceInterface {
 	public List<PlaceVO> searchPlacesByCategoryAndKeywordOrderByLike(String placeType, String category, String keyword) {
 		return dao.searchPlacesByCategoryAndKeywordOrderByLike(placeType, category, keyword);
 	}
-	
-	
+
+	public List<PlaceVO> searchNearbyPlaces(String placeType, String centerLon, String centerLat,
+			double radiusKm, String category, String keyword, boolean orderByLike) {
+		return dao.searchNearbyPlaces(placeType, centerLon, centerLat, radiusKm, category, keyword, orderByLike);
+	}
 
 }
 

--- a/src/com/letsgo/place/service/PlaceServiceInterface.java
+++ b/src/com/letsgo/place/service/PlaceServiceInterface.java
@@ -57,5 +57,9 @@ public interface PlaceServiceInterface {
     List<PlaceVO> searchPlacesByCategoryAndKeywordOrderByTitle(String placeType, String category, String keyword);
 
     List<PlaceVO> searchPlacesByCategoryAndKeywordOrderByLike(String placeType, String category, String keyword);
+
+    // 장바구니 내 LEISURE 좌표 기준 반경(km) 내 PLACE 조회 (식당/숙박)
+    List<PlaceVO> searchNearbyPlaces(String placeType, String centerLon, String centerLat,
+            double radiusKm, String category, String keyword, boolean orderByLike);
 }
 

--- a/src/com/letsgo/place/servlet/AddCartAction.java
+++ b/src/com/letsgo/place/servlet/AddCartAction.java
@@ -48,7 +48,13 @@ public class AddCartAction implements Action {
 			request.setAttribute("cartMessage", "숙박은 1개만 담을 수 있습니다.");
 			return new IndexUIAction().execute(request);
 		}
-	
+
+		// 식당/숙박은 레저 좌표 기준으로 조회되므로 레저가 먼저 담겨 있어야 한다
+		if (("RESTAURANT".equals(placeType) || "STAY".equals(placeType)) && !hasLeisurePlace(cartList)) {
+			request.setAttribute("cartMessage", "레저스포츠를 먼저 장바구니에 담아주세요.");
+			return new IndexUIAction().execute(request);
+		}
+
 		PlaceServiceInterface service = new PlaceServiceMB();
 		PlaceVO place = service.getPlaceById(placeId);
 		if (place != null) {

--- a/src/com/letsgo/place/servlet/CartUtil.java
+++ b/src/com/letsgo/place/servlet/CartUtil.java
@@ -1,0 +1,36 @@
+package com.letsgo.place.servlet;
+
+import java.util.List;
+
+import javax.servlet.http.HttpSession;
+
+import com.letsgo.place.model.vo.PlaceVO;
+
+final class CartUtil {
+
+	// 장바구니 내 LEISURE 좌표 기준 식당/숙박 검색 반경 (km).
+	// 차로 15~20분 동선을 가정한 값. 조정 시 이 상수만 바꾸면 모든 호출지점에 반영됨.
+	static final double NEARBY_RADIUS_KM = 10.0;
+
+	private CartUtil() {
+	}
+
+	@SuppressWarnings("unchecked")
+	static PlaceVO getLeisureInCart(HttpSession session) {
+		if (session == null) {
+			return null;
+		}
+		List<PlaceVO> cartList = (List<PlaceVO>) session.getAttribute("placeCartList");
+		if (cartList == null) {
+			return null;
+		}
+		for (PlaceVO place : cartList) {
+			if ("LEISURE".equals(place.getPlaceType())
+					&& place.getMapx() != null && !place.getMapx().isEmpty()
+					&& place.getMapy() != null && !place.getMapy().isEmpty()) {
+				return place;
+			}
+		}
+		return null;
+	}
+}

--- a/src/com/letsgo/place/servlet/RestaurantUIAction.java
+++ b/src/com/letsgo/place/servlet/RestaurantUIAction.java
@@ -1,4 +1,4 @@
-﻿package com.letsgo.place.servlet;
+package com.letsgo.place.servlet;
 
 import java.io.IOException;
 import java.sql.SQLException;
@@ -6,6 +6,7 @@ import java.util.List;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
 
 import com.letsgo.place.mybatis.service.PlaceServiceMB;
 import com.letsgo.place.model.vo.PlaceVO;
@@ -16,23 +17,26 @@ public class RestaurantUIAction implements Action {
 	@Override
 	public String execute(HttpServletRequest request)
 			throws ServletException, IOException, ClassNotFoundException, SQLException {
-		String sortOrder = request.getParameter("sortOrder");
-		PlaceServiceInterface placeService = new PlaceServiceMB();
-		
-        List<PlaceVO> restaurantPlaceList;
-        
-        if ("popular".equals(sortOrder)) {
-            restaurantPlaceList = placeService.getPlaceOrderByLike("RESTAURANT");
-        } else {
-            restaurantPlaceList = placeService.getPlaceOrderByTitle("RESTAURANT"); 
-        }
+		HttpSession session = request.getSession();
+		PlaceVO leisure = CartUtil.getLeisureInCart(session);
+		if (leisure == null) {
+			request.setAttribute("cartMessage", "레저스포츠를 먼저 장바구니에 담아주세요.");
+			return new LeisureUIAction().execute(request);
+		}
 
-        request.setAttribute("restaurantPlaceList", restaurantPlaceList);
-        request.setAttribute("totalCount", restaurantPlaceList.size());
-        
+		String sortOrder = request.getParameter("sortOrder");
+		boolean orderByLike = "popular".equals(sortOrder);
+		PlaceServiceInterface placeService = new PlaceServiceMB();
+
+		List<PlaceVO> restaurantPlaceList = placeService.searchNearbyPlaces(
+				"RESTAURANT", leisure.getMapx(), leisure.getMapy(),
+				CartUtil.NEARBY_RADIUS_KM, null, null, orderByLike);
+
+		request.setAttribute("restaurantPlaceList", restaurantPlaceList);
+		request.setAttribute("totalCount", restaurantPlaceList.size());
+		request.setAttribute("nearbyRadiusKm", CartUtil.NEARBY_RADIUS_KM);
+
 		return "restaurant.jsp";
-		
 	}
 
 }
-

--- a/src/com/letsgo/place/servlet/SearchPlaceAction.java
+++ b/src/com/letsgo/place/servlet/SearchPlaceAction.java
@@ -1,4 +1,4 @@
-﻿package com.letsgo.place.servlet;
+package com.letsgo.place.servlet;
 
 import java.io.IOException;
 import java.sql.SQLException;
@@ -6,6 +6,7 @@ import java.util.List;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
 
 import com.letsgo.place.mybatis.service.PlaceServiceMB;
 import com.letsgo.place.model.vo.PlaceVO;
@@ -16,34 +17,49 @@ public class SearchPlaceAction implements Action {
 	@Override
 	public String execute(HttpServletRequest request)
 			throws ServletException, IOException, ClassNotFoundException, SQLException {
-		
-        String placeType = request.getParameter("placeType"); 
-        String keyword = request.getParameter("keyword");     
-        String category = request.getParameter("category");   
-        String sortOrder = request.getParameter("sortOrder"); 
-        
+
+        String placeType = request.getParameter("placeType");
+        String keyword = request.getParameter("keyword");
+        String category = request.getParameter("category");
+        String sortOrder = request.getParameter("sortOrder");
+
         if (placeType == null || placeType.trim().isEmpty()) {
-            placeType = "LEISURE"; 
+            placeType = "LEISURE";
         }
 
         PlaceServiceInterface placeService = new PlaceServiceMB();
-        List<PlaceVO> placeList = searchPlaces(placeService, placeType, category, keyword, sortOrder);
-        
-        int totalCount = placeList.size(); 
-        request.setAttribute("totalCount", totalCount);
-        
-        if ("RESTAURANT".equals(placeType)) {
-            request.setAttribute("restaurantPlaceList", placeList);
-            return "restaurant.jsp";
-            
-        } else if ("STAY".equals(placeType)) {
+
+        // 식당/숙박은 장바구니 LEISURE 좌표 기준 반경 내 결과만 반환
+        if ("RESTAURANT".equals(placeType) || "STAY".equals(placeType)) {
+            HttpSession session = request.getSession();
+            PlaceVO leisure = CartUtil.getLeisureInCart(session);
+            if (leisure == null) {
+                request.setAttribute("cartMessage", "레저스포츠를 먼저 장바구니에 담아주세요.");
+                return new LeisureUIAction().execute(request);
+            }
+
+            boolean orderByLike = "popular".equals(sortOrder) || "like".equals(sortOrder);
+            String normalizedCategory = (category != null && !category.trim().isEmpty()) ? category : null;
+            String normalizedKeyword = (keyword != null && !keyword.trim().isEmpty()) ? keyword : null;
+
+            List<PlaceVO> placeList = placeService.searchNearbyPlaces(
+                    placeType, leisure.getMapx(), leisure.getMapy(),
+                    CartUtil.NEARBY_RADIUS_KM, normalizedCategory, normalizedKeyword, orderByLike);
+
+            request.setAttribute("totalCount", placeList.size());
+            request.setAttribute("nearbyRadiusKm", CartUtil.NEARBY_RADIUS_KM);
+            if ("RESTAURANT".equals(placeType)) {
+                request.setAttribute("restaurantPlaceList", placeList);
+                return "restaurant.jsp";
+            }
             request.setAttribute("stayPlaceList", placeList);
             return "stay.jsp";
-            
-        } else {
-            request.setAttribute("leisurePlaceList", placeList);
-            return "leisure.jsp";
         }
+
+        List<PlaceVO> placeList = searchPlaces(placeService, placeType, category, keyword, sortOrder);
+        request.setAttribute("totalCount", placeList.size());
+        request.setAttribute("leisurePlaceList", placeList);
+        return "leisure.jsp";
 	}
 
     private List<PlaceVO> searchPlaces(PlaceServiceInterface placeService, String placeType, String category,
@@ -71,4 +87,3 @@ public class SearchPlaceAction implements Action {
                 : placeService.searchPlacesOrderByTitle(placeType);
     }
 }
-

--- a/src/com/letsgo/place/servlet/StayUIAction.java
+++ b/src/com/letsgo/place/servlet/StayUIAction.java
@@ -1,4 +1,4 @@
-﻿package com.letsgo.place.servlet;
+package com.letsgo.place.servlet;
 
 import java.io.IOException;
 import java.sql.SQLException;
@@ -6,6 +6,7 @@ import java.util.List;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
 
 import com.letsgo.place.mybatis.service.PlaceServiceMB;
 import com.letsgo.place.model.vo.PlaceVO;
@@ -16,22 +17,26 @@ public class StayUIAction implements Action {
 	@Override
 	public String execute(HttpServletRequest request)
 			throws ServletException, IOException, ClassNotFoundException, SQLException {
+		HttpSession session = request.getSession();
+		PlaceVO leisure = CartUtil.getLeisureInCart(session);
+		if (leisure == null) {
+			request.setAttribute("cartMessage", "레저스포츠를 먼저 장바구니에 담아주세요.");
+			return new LeisureUIAction().execute(request);
+		}
+
 		String sortOrder = request.getParameter("sortOrder");
-	    PlaceServiceInterface placeService = new PlaceServiceMB();
-		
-		List<PlaceVO> stayPlaceList;
-		
-		if ("popular".equals(sortOrder)) {
-	        stayPlaceList = placeService.getPlaceOrderByLike("STAY");
-	    } else {
-	        stayPlaceList = placeService.getPlaceOrderByTitle("STAY");
-	    }
-		
-        request.setAttribute("stayPlaceList", stayPlaceList);
-        request.setAttribute("totalCount", stayPlaceList.size());
-        
+		boolean orderByLike = "popular".equals(sortOrder);
+		PlaceServiceInterface placeService = new PlaceServiceMB();
+
+		List<PlaceVO> stayPlaceList = placeService.searchNearbyPlaces(
+				"STAY", leisure.getMapx(), leisure.getMapy(),
+				CartUtil.NEARBY_RADIUS_KM, null, null, orderByLike);
+
+		request.setAttribute("stayPlaceList", stayPlaceList);
+		request.setAttribute("totalCount", stayPlaceList.size());
+		request.setAttribute("nearbyRadiusKm", CartUtil.NEARBY_RADIUS_KM);
+
 		return "stay.jsp";
 	}
 
 }
-

--- a/src/config/Place.xml
+++ b/src/config/Place.xml
@@ -310,4 +310,50 @@
 		ORDER BY LIKE_COUNT DESC
 	</select>
 
+	<!--
+		장바구니 내 LEISURE 좌표 기준 반경 (km) 내 PLACE 조회.
+		- mapx = 경도(longitude), mapy = 위도(latitude). 컬럼/파라미터 모두 VARCHAR이라 TO_NUMBER 변환
+		- 거리 계산: Haversine 공식 (R = 6371km), 0.017453292519943295 = π/180
+		- category, keywordPattern 은 선택 (null/빈문자열 → 조건 생략)
+		- orderByLike=true → 좋아요순, 그 외 → 거리순 (둘 다 반경 필터 적용)
+	-->
+	<select id="searchNearbyPlaces" parameterType="map" resultType="com.letsgo.place.model.vo.PlaceVO">
+		SELECT placeId, title, firstImage, addr1, mapx, mapy, likeCount, placeType
+		FROM (
+			SELECT PLACE_ID AS placeId,
+			       TITLE AS title,
+			       FIRST_IMAGE AS firstImage,
+			       ADDR1 AS addr1,
+			       MAPX AS mapx,
+			       MAPY AS mapy,
+			       LIKE_COUNT AS likeCount,
+			       #{placeType} AS placeType,
+			       (6371 * 2 * ASIN(SQRT(
+			           POWER(SIN((TO_NUMBER(MAPY) - TO_NUMBER(#{centerLat})) * 0.017453292519943295 / 2), 2)
+			         + COS(TO_NUMBER(MAPY) * 0.017453292519943295)
+			           * COS(TO_NUMBER(#{centerLat}) * 0.017453292519943295)
+			           * POWER(SIN((TO_NUMBER(MAPX) - TO_NUMBER(#{centerLon})) * 0.017453292519943295 / 2), 2)
+			       ))) AS distance_km
+			FROM PLACE
+			WHERE PLACE_TYPE = #{placeType}
+			  AND MAPX IS NOT NULL
+			  AND MAPY IS NOT NULL
+			<if test="category != null and category != ''">
+			  AND LCLSSYSTM3 = #{category}
+			</if>
+			<if test="keywordPattern != null and keywordPattern != ''">
+			  AND (TITLE LIKE #{keywordPattern} OR ADDR1 LIKE #{keywordPattern})
+			</if>
+		)
+		WHERE distance_km &lt;= #{radiusKm}
+		<choose>
+			<when test="orderByLike == true">
+		ORDER BY likeCount DESC, distance_km ASC
+			</when>
+			<otherwise>
+		ORDER BY distance_km ASC
+			</otherwise>
+		</choose>
+	</select>
+
 </mapper>


### PR DESCRIPTION
장바구니 기능 개선 — 식당/숙박 조회를 장바구니에 담긴 LEISURE
좌표 중심 10km 반경 내로 필터링하고, 담기 동작에 toast 피드백을 추가.
## 주요 변경
### 1. 반경 기반 식당/숙박 조회 (8b2adb0)
- 식당/숙박은 장바구니 LEISURE 의 (MAPX, MAPY) 를 중심으로 Haversine
  거리 10km 반경 내 결과만 반환. 그 안에서 거리순(기본) 또는
  좋아요순(인기순 선택 시) 정렬.
- 어떤 검색 경로(목록/카테고리/키워드/조합)로 진입해도 동일한 반경
  필터가 적용되도록 단일 동적 SQL/메서드(searchNearbyPlaces) 로 통합.
- LEISURE 가 카트에 없을 때 RESTAURANT/STAY 담기/조회 시도 시 차단
  하고 "레저스포츠를 먼저 장바구니에 담아주세요" 안내 후 leisure
  페이지로 리다이렉트. 클라이언트(floating-cart.js)에서도 동일 차단.
- 반경은 CartUtil.NEARBY_RADIUS_KM 상수로 분리 (조정 용이).
- MyBatis(Place.xml) + 레거시 JDBC(PlaceDAO/PlaceQuery) 양쪽 모두 반영.
### 2. 담기 성공 시 toast 알림 (f868392)
- 기존 fire-and-forget XHR 을 200 응답 대기 후 toast 로 피드백.
- alert 대신 비차단 toast 로 연속 담기 흐름이 끊기지 않도록 함.
- 2.5초 fade in/out, floating cart 버튼 위 중앙 위치.
## 영향 파일
- 신규: CartUtil.java
- 변경: PlaceDAO/Interface, PlaceDAOMB, PlaceQuery, PlaceService/Interface,
  PlaceServiceMB, AddCartAction, RestaurantUIAction, StayUIAction,
  SearchPlaceAction, Place.xml, floating-cart.js/css